### PR TITLE
Upgrade memcached to 2.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "MIT",
   "dependencies": {
     "lodash": "~2.4.1",
-    "memcached": "~2.1.0"
+    "memcached": "~2.2.0"
   },
   "devDependencies": {
     "mocha": "~1.20.1",


### PR DESCRIPTION
Upgrading memcached version to 2.2.0 allowed the plugin to run. npm install consistently crashed when trying to install version 2.1.0 - only installation of 2.2.0 was successful.
